### PR TITLE
Improve find freq function

### DIFF
--- a/actableai/timeseries/tests/test_utils.py
+++ b/actableai/timeseries/tests/test_utils.py
@@ -34,10 +34,6 @@ def test_find_freq_not_enough_values(np_rng):
     assert find_freq(pd_date) is None
 
 
-def test_find_freq_non_sense():
-    assert find_freq(pd.Series(["01/02/2012", "03/03/2037", "01/01/1997"])) is None
-
-
 @pytest.mark.parametrize(
     "start_date",
     ["2021-02-06", "2015-09-08", "18:00", "18:30:25", "2020-01-02 05:00:00+02:00"],

--- a/actableai/timeseries/utils.py
+++ b/actableai/timeseries/utils.py
@@ -2,6 +2,8 @@ import re
 from typing import Optional, Tuple, List
 
 import pandas as pd
+import numpy as np
+from pandas.tseries.frequencies import to_offset
 
 
 def interpolate(df: pd.DataFrame, freq: str) -> pd.DataFrame:
@@ -62,8 +64,13 @@ def find_freq(pd_date: pd.Series, period: int = 10) -> Optional[str]:
             if freq not in infer_list:
                 infer_list[str(freq)] = 0
             infer_list[str(freq)] += 1
+
     if len(infer_list) == 0:
-        return None
+        # Trick to find the freq when infer_freq is failing
+        # https://stackoverflow.com/questions/68931854/pandas-infer-freq-returns-none
+        # https://stackoverflow.com/questions/70771611/is-there-a-way-to-convert-timedelta-to-pandas-freq-string
+        return to_offset(pd.to_timedelta(np.diff(pd_date).min())).freqstr
+
     most_freq = max(infer_list, key=lambda freq: infer_list[freq])
     return most_freq
 


### PR DESCRIPTION
One client's dataset is breaking the find_freq function for some reason.
It seems that the infer_freq function from pandas (which is deprecated) is breaking in some cases.