### PR TITLE
Use only FASTAI and NN_TORCH for quantile regression

### DIFF
--- a/actableai/tasks/regression.py
+++ b/actableai/tasks/regression.py
@@ -450,6 +450,7 @@ class AAIRegressionTask(AAITask):
         from actableai.utils import (
             memory_efficient_hyperparameters,
             explanation_hyperparameters,
+            quantile_regression_hyperparameters,
         )
         from actableai.data_validation.params import RegressionDataValidator
         from actableai.data_validation.base import (
@@ -556,7 +557,9 @@ class AAIRegressionTask(AAITask):
             eval_metric = "pinball_loss"
 
         if hyperparameters is None:
-            if explain_samples:
+            if prediction_quantiles is not None:
+                hyperparameters = quantile_regression_hyperparameters()
+            elif explain_samples:
                 hyperparameters = explanation_hyperparameters()
             else:
                 any_text_cols = df.apply(check_if_nlp_feature).any(axis=None)

--- a/actableai/utils/__init__.py
+++ b/actableai/utils/__init__.py
@@ -242,6 +242,13 @@ def debiasing_hyperparameters():
     return {"LR": {"proc.skew_threshold": np.inf}}
 
 
+def quantile_regression_hyperparameters():
+    return {
+        "FASTAI": {},
+        "NN_TORCH": {},
+    }
+
+
 def explanation_hyperparameters():
     from autogluon.tabular.configs.hyperparameter_configs import (
         hyperparameter_config_dict,


### PR DESCRIPTION
Tree-based models use too much memory so we limit default models for quantile regression only with FastAI and NN.